### PR TITLE
add a DeploymentExceptionTransformer to the TCK

### DIFF
--- a/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceExtension.java
+++ b/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceExtension.java
@@ -15,6 +15,7 @@
  */
 package io.smallrye.faulttolerance.tck;
 
+import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 
@@ -27,6 +28,7 @@ public class FaultToleranceExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
         builder.service(ApplicationArchiveProcessor.class, FaultToleranceApplicationArchiveProcessor.class);
+        builder.service(DeploymentExceptionTransformer.class, TckDeploymentExceptionTransformer.class);
     }
 
 }

--- a/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/TckDeploymentExceptionTransformer.java
+++ b/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/TckDeploymentExceptionTransformer.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.tck;
+
+import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
+
+public class TckDeploymentExceptionTransformer implements DeploymentExceptionTransformer {
+    @Override
+    public Throwable transform(Throwable exception) {
+        if (exception instanceof org.jboss.weld.exceptions.DefinitionException) {
+            Throwable[] suppressed = exception.getSuppressed();
+            if (suppressed.length == 1) {
+                return suppressed[0];
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This `DeploymentExceptionTransformer` extracts an underlying
exception from Weld's `DefinitionException`, if there's exactly one,
because this is now expected by the TCK (see [1]).

[1] https://github.com/eclipse/microprofile-fault-tolerance/issues/355