### PR TITLE
make sure the tested archive contains beans.xml

### DIFF
--- a/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -55,6 +55,11 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
             classContainer.addClass(HystrixCommandSemaphoreCleanup.class);
             classContainer.addAsResource(EmptyAsset.INSTANCE, "META-INF/beans.xml");
         }
+
+        if (!applicationArchive.contains("META-INF/beans.xml")) {
+            applicationArchive.add(EmptyAsset.INSTANCE, "META-INF/beans.xml");
+        }
+
         LOGGER.info("Added additional resources to " + applicationArchive.toString(true));
     }
 }


### PR DESCRIPTION
Some TCK tests don't add `beans.xml` to the main tested archive.
This commit changes the `ApplicationArchiveProcessor` to add
empty `beans.xml` to such archives, because CDI simply needs
to be enabled.